### PR TITLE
rename ModelError to ApiError

### DIFF
--- a/examples/api-util.ts
+++ b/examples/api-util.ts
@@ -1,7 +1,7 @@
-import { APIError } from "@sajari/sdk-node";
+import { ApiError } from "@sajari/sdk-node";
 
 export const handleError = (e: any) => {
-  if (e instanceof APIError) {
+  if (e instanceof ApiError) {
     const msg = [
       `Message: ${e.message}`,
       `Code: ${e.code}`,

--- a/generate/docker.bash
+++ b/generate/docker.bash
@@ -43,5 +43,6 @@ docker build -f Dockerfile.post-generate -t $img .
 docker run --rm -it \
     -v "$GEN_PATH":/app/gen \
     -v $(pwd)/post-generate.bash:/app/post-generate.bash \
+    -e GEN_PATH=/app/gen \
     $img \
     ./post-generate.bash

--- a/generate/generate.bash
+++ b/generate/generate.bash
@@ -10,7 +10,7 @@ function die() {
 }
 
 if [ -z "$GEN_PATH" ]; then
-    die "GEN_PATH must be set, e.g. /path/to/src/generated"
+    die "GEN_PATH must be set, e.g. /path/to/sajari/sdk-node/src/generated"
 fi
 if [ -z "$TEMPLATES_PATH" ]; then
     die "TEMPLATES_PATH must be set, e.g. /path/to/sajari/sdk-node/generate/templates"

--- a/generate/post-generate.bash
+++ b/generate/post-generate.bash
@@ -4,4 +4,15 @@ set -eo pipefail
 
 cd "$(dirname "$0")"
 
+if [ -z "$GEN_PATH" ]; then
+    die "GEN_PATH must be set, e.g. /path/to/sajari/sdk-node/src/generated"
+fi
+
+# In the OpenAPI spec the error response is named Error but that conflicts with
+# the JavaScript Error. Instead of ModelError, which the generator uses, we
+# manually change it to ApiError.
+mv $GEN_PATH/model/modelError.ts $GEN_PATH/model/apiError.ts
+find $GEN_PATH -type f -exec sed -i 's/ModelError/ApiError/g' {} +
+find $GEN_PATH -type f -exec sed -i 's/modelError/apiError/g' {} +
+
 npm run format

--- a/src/api-util.ts
+++ b/src/api-util.ts
@@ -1,16 +1,11 @@
-import {
-  HttpError,
-  ModelError as APIError,
-  ObjectSerializer,
-} from "./generated/api";
+import { HttpError, ApiError, ObjectSerializer } from "./generated/api";
 
 export const handleError = (e: any) => {
   if (e instanceof HttpError) {
     try {
       const resp = JSON.parse(JSON.stringify(e.response));
       if (resp.body) {
-        const f = ObjectSerializer.deserialize(resp.body, "ModelError");
-        return f as APIError;
+        return ObjectSerializer.deserialize(resp.body, "ApiError") as ApiError;
       }
     } catch (e) {
       return e;

--- a/src/collections.test.ts
+++ b/src/collections.test.ts
@@ -3,7 +3,7 @@ import ksuid from "ksuid";
 import { CollectionsClient, withKeyCredentials } from "./collections";
 import { server, rest } from "./test/server";
 import { endpoint, ErrorResponse, errorResponse } from "./test/api-util";
-import { APIError } from ".";
+import { ApiError } from ".";
 
 jest.mock("./version", () => ({
   version: "1.2.3-test",
@@ -20,7 +20,7 @@ test("create collection", async () => {
   await client.createCollection({ id: newId(), displayName: "My collection" });
 });
 
-test("server error turns into thrown APIError", async () => {
+test("server error turns into thrown ApiError", async () => {
   server.use(
     rest.post<{}, ErrorResponse>(
       `${endpoint}/v4/collections`,
@@ -37,7 +37,7 @@ test("server error turns into thrown APIError", async () => {
       displayName: "My collection",
     });
   } catch (e) {
-    expect(e).toBeInstanceOf(APIError);
+    expect(e).toBeInstanceOf(ApiError);
     expect(e).toEqual(
       expect.objectContaining({
         code: 3,

--- a/src/generated/.openapi-generator/FILES
+++ b/src/generated/.openapi-generator/FILES
@@ -26,7 +26,7 @@ model/listCollectionsResponse.ts
 model/listPipelinesRequestView.ts
 model/listPipelinesResponse.ts
 model/listSchemaFieldsResponse.ts
-model/modelError.ts
+model/apiError.ts
 model/pipeline.ts
 model/pipelineStep.ts
 model/pipelineStepParamBinding.ts

--- a/src/generated/model/apiError.ts
+++ b/src/generated/model/apiError.ts
@@ -13,7 +13,7 @@
 import { RequestFile } from "./models";
 import { ProtobufAny } from "./protobufAny";
 
-export class ModelError {
+export class ApiError {
   "code"?: number;
   "message"?: string;
   "details"?: Array<ProtobufAny>;
@@ -43,6 +43,6 @@ export class ModelError {
   ];
 
   static getAttributeTypeMap() {
-    return ModelError.attributeTypeMap;
+    return ApiError.attributeTypeMap;
   }
 }

--- a/src/generated/model/models.ts
+++ b/src/generated/model/models.ts
@@ -21,7 +21,7 @@ export * from "./listCollectionsResponse";
 export * from "./listPipelinesRequestView";
 export * from "./listPipelinesResponse";
 export * from "./listSchemaFieldsResponse";
-export * from "./modelError";
+export * from "./apiError";
 export * from "./pipeline";
 export * from "./pipelineStep";
 export * from "./pipelineStepParamBinding";
@@ -89,7 +89,7 @@ import { ListCollectionsResponse } from "./listCollectionsResponse";
 import { ListPipelinesRequestView } from "./listPipelinesRequestView";
 import { ListPipelinesResponse } from "./listPipelinesResponse";
 import { ListSchemaFieldsResponse } from "./listSchemaFieldsResponse";
-import { ModelError } from "./modelError";
+import { ApiError } from "./apiError";
 import { Pipeline } from "./pipeline";
 import { PipelineStep } from "./pipelineStep";
 import { PipelineStepParamBinding } from "./pipelineStepParamBinding";
@@ -166,7 +166,7 @@ let typeMap: { [index: string]: any } = {
   ListCollectionsResponse: ListCollectionsResponse,
   ListPipelinesResponse: ListPipelinesResponse,
   ListSchemaFieldsResponse: ListSchemaFieldsResponse,
-  ModelError: ModelError,
+  ApiError: ApiError,
   Pipeline: Pipeline,
   PipelineStep: PipelineStep,
   PipelineStepParamBinding: PipelineStepParamBinding,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export { RecordsClient } from "./records";
 
 export {
   HttpError,
-  ModelError as APIError,
+  ApiError,
   SchemaFieldType,
   SchemaField,
   SchemaFieldMode,


### PR DESCRIPTION
The class name ModelError can leak out into logs and it makes no sense
to users even though we had aliased it to ApiError in the TS module.