### PR TITLE
run codegen to fix incorrect error response types

### DIFF
--- a/src/generated/api/collectionsApi.ts
+++ b/src/generated/api/collectionsApi.ts
@@ -18,7 +18,6 @@ import { Collection } from "../model/collection";
 import { ListCollectionsResponse } from "../model/listCollectionsResponse";
 import { QueryCollectionRequest } from "../model/queryCollectionRequest";
 import { QueryCollectionResponse } from "../model/queryCollectionResponse";
-import { Status } from "../model/status";
 
 import {
   ObjectSerializer,
@@ -428,7 +427,7 @@ export class CollectionsApi {
    * Retrieve a list of collections in the account.
    * @summary List collections
    * @param pageSize The maximum number of collections to return. The service may return fewer than this value.  If unspecified, at most 50 collections are returned.  The maximum value is 100; values above 100 are coerced to 100.
-   * @param pageToken A page token, received from a previous [ListCollections](/docs/api-reference#operation/ListCollections) call.  Provide this to retrieve the subsequent page.  When paginating, all other parameters provided to [ListCollections](/docs/api-reference#operation/ListCollections) must match the call that provided the page token.
+   * @param pageToken A page token, received from a previous [ListCollections](/api#operation/ListCollections) call.  Provide this to retrieve the subsequent page.  When paginating, all other parameters provided to [ListCollections](/api#operation/ListCollections) must match the call that provided the page token.
    */
   public async listCollections(
     pageSize?: number,
@@ -535,7 +534,7 @@ export class CollectionsApi {
     });
   }
   /**
-   * Query the collection to search for records.  The following example demonstrates how to run a simple search for a particular string:  ```json {   \"variables\": { \"q\": \"search terms\" } } ```  For more information:  - See [filtering content](https://www.sajari.com/docs/user-guide/integrating-search/filters/) - See [tracking in the Go SDK](https://github.com/sajari/sdk-go/blob/v2/session.go) - See [tracking in the JS SDK](https://github.com/sajari/sajari-sdk-js/blob/master/src/session.ts)
+   * Query the collection to search for records.  The following example demonstrates how to run a simple search for a particular string:  ```json {   \"variables\": { \"q\": \"search terms\" } } ```  For more information:  - See [filtering content](https://docs.sajari.com/user-guide/integrating-search/filters/) - See [tracking in the Go SDK](https://github.com/sajari/sdk-go/blob/v2/session.go) - See [tracking in the JS SDK](https://github.com/sajari/sajari-sdk-js/blob/master/src/session.ts)
    * @summary Query collection
    * @param collectionId The collection to query, e.g. &#x60;my-collection&#x60;.
    * @param queryCollectionRequest

--- a/src/generated/api/pipelinesApi.ts
+++ b/src/generated/api/pipelinesApi.ts
@@ -21,7 +21,6 @@ import { ListPipelinesResponse } from "../model/listPipelinesResponse";
 import { Pipeline } from "../model/pipeline";
 import { SetDefaultPipelineRequest } from "../model/setDefaultPipelineRequest";
 import { SetDefaultVersionRequest } from "../model/setDefaultVersionRequest";
-import { Status } from "../model/status";
 
 import {
   ObjectSerializer,
@@ -477,7 +476,7 @@ export class PipelinesApi {
    * @param collectionId The collection that owns the pipeline to get the default version of, e.g. &#x60;my-collection&#x60;.
    * @param type The type of the pipeline to get the default version of.
    * @param name The name of the pipeline to get the default version of, e.g. &#x60;my-pipeline&#x60;.
-   * @param view The amount of information to include in the retrieved pipeline.   - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the &#x60;BASIC&#x60; view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/docs/api-reference#operation/ListPipelines) and [GetPipeline](/docs/api-reference#operation/GetPipeline)).  - FULL: Include the information from &#x60;BASIC&#x60;, plus full step configuration.
+   * @param view The amount of information to include in the retrieved pipeline.   - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the &#x60;BASIC&#x60; view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/api#operation/ListPipelines) and [GetPipeline](/api#operation/GetPipeline)).  - FULL: Include the information from &#x60;BASIC&#x60;, plus full step configuration.
    */
   public async getDefaultVersion(
     collectionId: string,
@@ -607,7 +606,7 @@ export class PipelinesApi {
    * @param type The type of the pipeline to retrieve.
    * @param name The name of the pipeline to retrieve, e.g. &#x60;my-pipeline&#x60;.
    * @param version The version of the pipeline to retrieve, e.g. &#x60;42&#x60;.
-   * @param view The amount of information to include in the retrieved pipeline.   - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the &#x60;BASIC&#x60; view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/docs/api-reference#operation/ListPipelines) and [GetPipeline](/docs/api-reference#operation/GetPipeline)).  - FULL: Include the information from &#x60;BASIC&#x60;, plus full step configuration.
+   * @param view The amount of information to include in the retrieved pipeline.   - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the &#x60;BASIC&#x60; view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/api#operation/ListPipelines) and [GetPipeline](/api#operation/GetPipeline)).  - FULL: Include the information from &#x60;BASIC&#x60;, plus full step configuration.
    */
   public async getPipeline(
     collectionId: string,
@@ -744,8 +743,8 @@ export class PipelinesApi {
    * @summary List pipelines
    * @param collectionId The collection that owns this set of pipelines, e.g. &#x60;my-collection&#x60;.
    * @param pageSize The maximum number of pipelines to return. The service may return fewer than this value.  If unspecified, at most 50 pipelines are returned.  The maximum value is 1000; values above 1000 are coerced to 1000.
-   * @param pageToken A page token, received from a previous [ListPipelines](/docs/api-reference#operation/ListPipelines) call.  Provide this to retrieve the subsequent page.  When paginating, all other parameters provided to [ListPipelines](/docs/api-reference#operation/ListPipelines) must match the call that provided the page token.
-   * @param view The amount of information to include in each retrieved pipeline.   - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the &#x60;BASIC&#x60; view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/docs/api-reference#operation/ListPipelines) and [GetPipeline](/docs/api-reference#operation/GetPipeline)).  - FULL: Include the information from &#x60;BASIC&#x60;, plus full step configuration.
+   * @param pageToken A page token, received from a previous [ListPipelines](/api#operation/ListPipelines) call.  Provide this to retrieve the subsequent page.  When paginating, all other parameters provided to [ListPipelines](/api#operation/ListPipelines) must match the call that provided the page token.
+   * @param view The amount of information to include in each retrieved pipeline.   - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the &#x60;BASIC&#x60; view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/api#operation/ListPipelines) and [GetPipeline](/api#operation/GetPipeline)).  - FULL: Include the information from &#x60;BASIC&#x60;, plus full step configuration.
    */
   public async listPipelines(
     collectionId: string,

--- a/src/generated/api/recordsApi.ts
+++ b/src/generated/api/recordsApi.ts
@@ -117,7 +117,7 @@ export class RecordsApi {
   }
 
   /**
-   * The batch version of the [UpsertRecord](/docs/api-reference#operation/UpsertRecord) call.
+   * The batch version of the [UpsertRecord](/api#operation/UpsertRecord) call.
    * @summary Batch upsert records
    * @param collectionId The collection to upsert the records in, e.g. &#x60;my-collection&#x60;.
    * @param batchUpsertRecordsRequest

--- a/src/generated/api/schemaApi.ts
+++ b/src/generated/api/schemaApi.ts
@@ -115,7 +115,7 @@ export class SchemaApi {
   }
 
   /**
-   * The batch version of the [CreateSchemaField](/docs/api-reference#operation/CreateSchemaField) call.
+   * The batch version of the [CreateSchemaField](/api#operation/CreateSchemaField) call.
    * @summary Batch create schema fields
    * @param collectionId The collection to create the schema fields in, e.g. &#x60;my-collection&#x60;.
    * @param batchCreateSchemaFieldsRequest
@@ -350,7 +350,7 @@ export class SchemaApi {
    * @summary List schema fields
    * @param collectionId The collection that owns this set of schema fields, e.g. &#x60;my-collection&#x60;.
    * @param pageSize The maximum number of schema fields to return. The service may return fewer than this value.  If unspecified, at most 50 schema fields are returned.  The maximum value is 1000; values above 1000 are coerced to 1000.
-   * @param pageToken A page token, received from a previous [ListSchemaFields](/docs/api-reference#operation/ListSchemaFields) call.  Provide this to retrieve the subsequent page.  When paginating, all other parameters provided to [ListSchemaFields](/docs/api-reference#operation/ListSchemaFields) must match the call that provided the page token.
+   * @param pageToken A page token, received from a previous [ListSchemaFields](/api#operation/ListSchemaFields) call.  Provide this to retrieve the subsequent page.  When paginating, all other parameters provided to [ListSchemaFields](/api#operation/ListSchemaFields) must match the call that provided the page token.
    */
   public async listSchemaFields(
     collectionId: string,

--- a/src/generated/model/collection.ts
+++ b/src/generated/model/collection.ts
@@ -30,7 +30,7 @@ export class Collection {
    */
   "displayName": string;
   /**
-   * The list of authorized query domains for the collection.  Client-side / browser requests to the [QueryCollection](/docs/api-reference#operation/QueryCollection) call can be made by any authorized query domain or any of its subdomains. This allows your interface to make search requests without having to provide an API key in the client-side request.
+   * The list of authorized query domains for the collection.  Client-side / browser requests to the [QueryCollection](/api#operation/QueryCollection) call can be made by any authorized query domain or any of its subdomains. This allows your interface to make search requests without having to provide an API key in the client-side request.
    */
   "authorizedQueryDomains"?: Array<string>;
 

--- a/src/generated/model/getDefaultVersionRequestView.ts
+++ b/src/generated/model/getDefaultVersionRequestView.ts
@@ -13,7 +13,7 @@
 import { RequestFile } from "./models";
 
 /**
- *  - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the `BASIC` view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/docs/api-reference#operation/ListPipelines) and [GetPipeline](/docs/api-reference#operation/GetPipeline)).  - FULL: Include the information from `BASIC`, plus full step configuration.
+ *  - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the `BASIC` view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/api#operation/ListPipelines) and [GetPipeline](/api#operation/GetPipeline)).  - FULL: Include the information from `BASIC`, plus full step configuration.
  */
 export enum GetDefaultVersionRequestView {
   ViewUnspecified = <any>"VIEW_UNSPECIFIED",

--- a/src/generated/model/getPipelineRequestView.ts
+++ b/src/generated/model/getPipelineRequestView.ts
@@ -13,7 +13,7 @@
 import { RequestFile } from "./models";
 
 /**
- *  - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the `BASIC` view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/docs/api-reference#operation/ListPipelines) and [GetPipeline](/docs/api-reference#operation/GetPipeline)).  - FULL: Include the information from `BASIC`, plus full step configuration.
+ *  - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the `BASIC` view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/api#operation/ListPipelines) and [GetPipeline](/api#operation/GetPipeline)).  - FULL: Include the information from `BASIC`, plus full step configuration.
  */
 export enum GetPipelineRequestView {
   ViewUnspecified = <any>"VIEW_UNSPECIFIED",

--- a/src/generated/model/listPipelinesRequestView.ts
+++ b/src/generated/model/listPipelinesRequestView.ts
@@ -13,7 +13,7 @@
 import { RequestFile } from "./models";
 
 /**
- *  - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the `BASIC` view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/docs/api-reference#operation/ListPipelines) and [GetPipeline](/docs/api-reference#operation/GetPipeline)).  - FULL: Include the information from `BASIC`, plus full step configuration.
+ *  - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the `BASIC` view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/api#operation/ListPipelines) and [GetPipeline](/api#operation/GetPipeline)).  - FULL: Include the information from `BASIC`, plus full step configuration.
  */
 export enum ListPipelinesRequestView {
   ViewUnspecified = <any>"VIEW_UNSPECIFIED",


### PR DESCRIPTION
Previously the OpenAPI spec left the error response types.